### PR TITLE
Add canonical infoblox.authz.v1 schema (authz Rule method annotation)

### DIFF
--- a/proto/infoblox/authz/v1/authz.proto
+++ b/proto/infoblox/authz/v1/authz.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package infoblox.authz.v1;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/infobloxopen/apis/proto/infoblox/authz/v1;authzv1";
+
+// Rule declares the authorization requirement for an RPC. Attach it to a method;
+// a framework builds the per-method rule table from these annotations, enforces
+// them (fail-closed), and generates a permission catalog from them.
+//
+// The declaration is ENGINE-NEUTRAL: it names WHAT is required (a verb on a
+// resource), not HOW it is evaluated. It carries no engine- or policy-specific
+// fields — those belong in adapters, not in the canonical schema.
+message Rule {
+  // The canonical permission verb. Standard set: get, list, watch, create,
+  // update, delete. Custom verbs (e.g. "download") are allowed as free strings.
+  // ("read" is intentionally not canonical; it maps to the View group =
+  // get + list + watch.)
+  string verb = 1;
+
+  // The resource the verb applies to, as a type or a template over request
+  // fields, e.g. "zone" or "zone:{zone_id}".
+  string resource = 2;
+
+  // If true, the method requires no authorization — the explicit, auditable
+  // opt-out. A method with neither a verb nor public=true should be denied at
+  // runtime and fail a boot-time completeness gate.
+  bool public = 3;
+}
+
+extend google.protobuf.MethodOptions {
+  // TODO(authz): 50001 is a PLACEHOLDER in protobuf's 50000-99999 "internal use"
+  // range. Reserve a globally-unique extension number from the protobuf registry
+  // (protobuf-global-extension-registry@google.com) before this is depended upon
+  // broadly.
+  Rule rule = 50001;
+}


### PR DESCRIPTION
Adds the engine-neutral authorization annotation as a canonical apx schema.

## What

`proto/infoblox/authz/v1/authz.proto` — a `Rule` extension on `google.protobuf.MethodOptions` (`verb`, `resource`, `public`). A service annotates each RPC with the verb + resource it requires; tooling reads these to enforce authorization (fail-closed) and to generate a permission catalog (standard verbs `get/list/watch/create/update/delete` + `View`/`Manage` groups). It is **engine-neutral** — it names *what* is required, not *how* it is evaluated, and carries no engine/ORM options (the repo policy forbids `gorm.`; this has none).

Consumed by the SDK at https://github.com/infobloxopen/devedge-sdk — `authz/authzpb` (reflection) or `protoc-gen-devedge-authz` (codegen) turn this annotation into a typed rule table.

## Validation

- `apx lint proto/infoblox/authz/v1/authz.proto` ✓
- Suggested release: `proto/infoblox/authz/v1` @ `v1.0.0-alpha.1`, lifecycle `experimental` (major 1 matches the `/v1` line; `-alpha.1` for experimental).

## Note

Extension number `50001` is a placeholder (protobuf 50000–99999 internal-use range). Reserving a globally-unique number before broad adoption is tracked in an inline TODO.
