### PR TITLE
Fix release pipeline: sync third-party protos + drop stale apx.yaml key

### DIFF
--- a/apx.yaml
+++ b/apx.yaml
@@ -46,8 +46,6 @@ tools:
         version: v6.11.0
     avrotool:
         version: 1.11.3
-    jsonschemadiff:
-        version: 0.3.0
 
 execution:
     mode: local

--- a/proto/google/protobuf/any.proto
+++ b/proto/google/protobuf/any.proto
@@ -42,121 +42,65 @@ option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 // `Any` contains an arbitrary serialized protocol buffer message along with a
 // URL that describes the type of the serialized message.
 //
-// Protobuf library provides support to pack/unpack Any values in the form
-// of utility functions or additional generated methods of the Any type.
+// In its binary encoding, an `Any` is an ordinary message; but in other wire
+// forms like JSON, it has a special encoding. The format of the type URL is
+// described on the `type_url` field.
 //
-// Example 1: Pack and unpack a message in C++.
+// Protobuf APIs provide utilities to interact with `Any` values:
 //
-//     Foo foo = ...;
-//     Any any;
-//     any.PackFrom(foo);
-//     ...
-//     if (any.UnpackTo(&foo)) {
-//       ...
-//     }
+// - A 'pack' operation accepts a message and constructs a generic `Any` wrapper
+//   around it.
+// - An 'unpack' operation reads the content of an `Any` message, either into an
+//   existing message or a new one. Unpack operations must check the type of the
+//   value they unpack against the declared `type_url`.
+// - An 'is' operation decides whether an `Any` contains a message of the given
+//   type, i.e. whether it can 'unpack' that type.
 //
-// Example 2: Pack and unpack a message in Java.
+// The JSON format representation of an `Any` follows one of these cases:
 //
-//     Foo foo = ...;
-//     Any any = Any.pack(foo);
-//     ...
-//     if (any.is(Foo.class)) {
-//       foo = any.unpack(Foo.class);
-//     }
-//     // or ...
-//     if (any.isSameTypeAs(Foo.getDefaultInstance())) {
-//       foo = any.unpack(Foo.getDefaultInstance());
-//     }
+// - For types without special-cased JSON encodings, the JSON format
+//   representation of the `Any` is the same as that of the message, with an
+//   additional `@type` field which contains the type URL.
+// - For types with special-cased JSON encodings (typically called 'well-known'
+//   types, listed in https://protobuf.dev/programming-guides/json/#any), the
+//   JSON format representation has a key `@type` which contains the type URL
+//   and a key `value` which contains the JSON-serialized value.
 //
-//  Example 3: Pack and unpack a message in Python.
-//
-//     foo = Foo(...)
-//     any = Any()
-//     any.Pack(foo)
-//     ...
-//     if any.Is(Foo.DESCRIPTOR):
-//       any.Unpack(foo)
-//       ...
-//
-//  Example 4: Pack and unpack a message in Go
-//
-//      foo := &pb.Foo{...}
-//      any, err := anypb.New(foo)
-//      if err != nil {
-//        ...
-//      }
-//      ...
-//      foo := &pb.Foo{}
-//      if err := any.UnmarshalTo(foo); err != nil {
-//        ...
-//      }
-//
-// The pack methods provided by protobuf library will by default use
-// 'type.googleapis.com/full.type.name' as the type URL and the unpack
-// methods only use the fully qualified type name after the last '/'
-// in the type URL, for example "foo.bar.com/x/y.z" will yield type
-// name "y.z".
-//
-// JSON
-// ====
-// The JSON representation of an `Any` value uses the regular
-// representation of the deserialized, embedded message, with an
-// additional field `@type` which contains the type URL. Example:
-//
-//     package google.profile;
-//     message Person {
-//       string first_name = 1;
-//       string last_name = 2;
-//     }
-//
-//     {
-//       "@type": "type.googleapis.com/google.profile.Person",
-//       "firstName": <string>,
-//       "lastName": <string>
-//     }
-//
-// If the embedded message type is well-known and has a custom JSON
-// representation, that representation will be embedded adding a field
-// `value` which holds the custom JSON in addition to the `@type`
-// field. Example (for message [google.protobuf.Duration][]):
-//
-//     {
-//       "@type": "type.googleapis.com/google.protobuf.Duration",
-//       "value": "1.212s"
-//     }
-//
+// The text format representation of an `Any` is like a message with one field
+// whose name is the type URL in brackets. For example, an `Any` containing a
+// `foo.Bar` message may be written `[type.googleapis.com/foo.Bar] { a: 2 }`.
 message Any {
-  // A URL/resource name that uniquely identifies the type of the serialized
-  // protocol buffer message. This string must contain at least
-  // one "/" character. The last segment of the URL's path must represent
-  // the fully qualified name of the type (as in
-  // `path/google.protobuf.Duration`). The name should be in a canonical form
-  // (e.g., leading "." is not accepted).
+  // Identifies the type of the serialized Protobuf message with a URI reference
+  // consisting of a prefix ending in a slash and the fully-qualified type name.
   //
-  // In practice, teams usually precompile into the binary all types that they
-  // expect it to use in the context of Any. However, for URLs which use the
-  // scheme `http`, `https`, or no scheme, one can optionally set up a type
-  // server that maps type URLs to message definitions as follows:
+  // Example: type.googleapis.com/google.protobuf.StringValue
   //
-  // * If no scheme is provided, `https` is assumed.
-  // * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-  //   value in binary format, or produce an error.
-  // * Applications are allowed to cache lookup results based on the
-  //   URL, or have them precompiled into a binary to avoid any
-  //   lookup. Therefore, binary compatibility needs to be preserved
-  //   on changes to types. (Use versioned type names to manage
-  //   breaking changes.)
+  // This string must contain at least one `/` character, and the content after
+  // the last `/` must be the fully-qualified name of the type in canonical
+  // form, without a leading dot. Do not write a scheme on these URI references
+  // so that clients do not attempt to contact them.
   //
-  // Note: this functionality is not currently available in the official
-  // protobuf release, and it is not used for type URLs beginning with
-  // type.googleapis.com. As of May 2023, there are no widely used type server
-  // implementations and no plans to implement one.
+  // The prefix is arbitrary and Protobuf implementations are expected to
+  // simply strip off everything up to and including the last `/` to identify
+  // the type. `type.googleapis.com/` is a common default prefix that some
+  // legacy implementations require. This prefix does not indicate the origin of
+  // the type, and URIs containing it are not expected to respond to any
+  // requests.
   //
-  // Schemes other than `http`, `https` (or the empty scheme) might be
-  // used with implementation specific semantics.
+  // All type URL strings must be legal URI references with the additional
+  // restriction (for the text format) that the content of the reference
+  // must consist only of alphanumeric characters, percent-encoded escapes, and
+  // characters in the following set (not including the outer backticks):
+  // `/-.~_!$&()*+,;=`. Despite our allowing percent encodings, implementations
+  // should not unescape them to prevent confusion with existing parsers. For
+  // example, `type.googleapis.com%2FFoo` should be rejected.
   //
+  // In the original design of `Any`, the possibility of launching a type
+  // resolution service at these type URLs was considered but Protobuf never
+  // implemented one and considers contacting these URLs to be problematic and
+  // a potential security issue. Do not attempt to contact type URLs.
   string type_url = 1;
 
-  // Must be a valid serialized protocol buffer of the above specified type.
+  // Holds a Protobuf serialization of the type described by type_url.
   bytes value = 2;
 }

--- a/proto/google/protobuf/cpp_features.proto
+++ b/proto/google/protobuf/cpp_features.proto
@@ -1,5 +1,5 @@
 // Protocol Buffers - Google's data interchange format
-// Copyright 2023 Google Inc.  All rights reserved.
+// Copyright 2023 Google LLC.  All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file or at
@@ -63,5 +63,25 @@ message CppFeatures {
     },
     edition_defaults = { edition: EDITION_LEGACY, value: "false" },
     edition_defaults = { edition: EDITION_2024, value: "true" }
+  ];
+
+  enum RepeatedType {
+    REPEATED_TYPE_UNKNOWN = 0;
+    // The repeated field will be backed by proto2::Repeated(Ptr)Field, and
+    // accessors will return a reference/pointer to this type.
+    LEGACY = 1;
+    // The repeated field has an opaque backing type, and accessors will return
+    // a RepeatedFieldProxy.
+    PROXY = 2;
+  }
+
+  optional RepeatedType repeated_type = 4 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    feature_support = {
+      edition_introduced: EDITION_UNSTABLE,
+    },
+    edition_defaults = { edition: EDITION_LEGACY, value: "LEGACY" }
   ];
 }

--- a/proto/google/protobuf/descriptor.proto
+++ b/proto/google/protobuf/descriptor.proto
@@ -1,32 +1,9 @@
 // Protocol Buffers - Google's data interchange format
-// Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
+// Copyright 2008 Google LLC.  All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
 
 // Author: kenton@google.com (Kenton Varda)
 //  Based on original Protocol Buffers design by
@@ -85,6 +62,7 @@ enum Edition {
   // comparison.
   EDITION_2023 = 1000;
   EDITION_2024 = 1001;
+  EDITION_2026 = 1002;
 
   // A placeholder edition for developing and testing unscheduled features.
   EDITION_UNSTABLE = 9999;
@@ -189,6 +167,9 @@ message DescriptorProto {
 }
 
 message ExtensionRangeOptions {
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -583,6 +564,14 @@ message FileOptions {
   // developers should rely on the protoreflect APIs for their client language.
   optional FeatureSet features = 50;
 
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998 [declaration = {
+    number: 990,
+    full_name: ".pb.file.cpp",
+    type: ".pb.file.CppFileOptions"
+  }];
+
   // The parser stores options it doesn't recognize here.
   // See the documentation for the "Options" section above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -671,6 +660,10 @@ message MessageOptions {
   // cases like the proto compiler. Other uses are discouraged and
   // developers should rely on the protoreflect APIs for their client language.
   optional FeatureSet features = 12;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -842,6 +835,10 @@ message FieldOptions {
   }
   optional FeatureSupport feature_support = 22;
 
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -858,6 +855,10 @@ message OneofOptions {
   // cases like the proto compiler. Other uses are discouraged and
   // developers should rely on the protoreflect APIs for their client language.
   optional FeatureSet features = 1;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -894,6 +895,10 @@ message EnumOptions {
   // developers should rely on the protoreflect APIs for their client language.
   optional FeatureSet features = 7;
 
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -922,6 +927,10 @@ message EnumValueOptions {
   // Information about the support window of a feature value.
   optional FieldOptions.FeatureSupport feature_support = 4;
 
+  // Range reserved for first-class extension options defined by the Protobuf
+  // team. Custom options must use the 1000+ range instead.
+  extensions 990 to 998;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -947,6 +956,10 @@ message ServiceOptions {
   // for the service, or it will be completely ignored; in the very least,
   // this is a formalization for deprecating services.
   optional bool deprecated = 33 [default = false];
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -984,6 +997,10 @@ message MethodOptions {
   // cases like the proto compiler. Other uses are discouraged and
   // developers should rely on the protoreflect APIs for their client language.
   optional FeatureSet features = 35;
+
+  // Range reserved for first-class custom options defined by the Protobuf
+  // team. User custom options must use the 1000+ range instead.
+  extensions 990 to 998;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -1133,6 +1150,7 @@ message FeatureSet {
     ENFORCE_NAMING_STYLE_UNKNOWN = 0;
     STYLE2024 = 1;
     STYLE_LEGACY = 2;
+    STYLE2026 = 3;
   }
   optional EnforceNamingStyle enforce_naming_style = 7 [
     retention = RETENTION_SOURCE,
@@ -1149,7 +1167,8 @@ message FeatureSet {
       edition_introduced: EDITION_2024,
     },
     edition_defaults = { edition: EDITION_LEGACY, value: "STYLE_LEGACY" },
-    edition_defaults = { edition: EDITION_2024, value: "STYLE2024" }
+    edition_defaults = { edition: EDITION_2024, value: "STYLE2024" },
+    edition_defaults = { edition: EDITION_UNSTABLE, value: "STYLE2026" }
   ];
 
   message VisibilityFeature {
@@ -1201,6 +1220,11 @@ message FeatureSet {
       number: 1003,
       full_name: ".pb.python",
       type: ".pb.PythonFeatures"
+    },
+    declaration = {
+      number: 1004,
+      full_name: ".pb.csharp",
+      type: ".pb.CSharpFeatures"
     },
     declaration = {
       number: 1100,

--- a/proto/google/protobuf/struct.proto
+++ b/proto/google/protobuf/struct.proto
@@ -40,55 +40,71 @@ option java_multiple_files = true;
 option objc_class_prefix = "GPB";
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 
-// `Struct` represents a structured data value, consisting of fields
-// which map to dynamically typed values. In some languages, `Struct`
-// might be supported by a native representation. For example, in
-// scripting languages like JS a struct is represented as an
-// object. The details of that representation are described together
-// with the proto support for the language.
+// Represents a JSON object.
 //
-// The JSON representation for `Struct` is JSON object.
+// An unordered key-value map, intending to perfectly capture the semantics of a
+// JSON object. This enables parsing any arbitrary JSON payload as a message
+// field in ProtoJSON format.
+//
+// This follows RFC 8259 guidelines for interoperable JSON: notably this type
+// cannot represent large Int64 values or `NaN`/`Infinity` numbers,
+// since the JSON format generally does not support those values in its number
+// type.
+//
+// If you do not intend to parse arbitrary JSON into your message, a custom
+// typed message should be preferred instead of using this type.
 message Struct {
   // Unordered map of dynamically typed values.
   map<string, Value> fields = 1;
 }
 
+// Represents a JSON value.
+//
 // `Value` represents a dynamically typed value which can be either
 // null, a number, a string, a boolean, a recursive struct value, or a
 // list of values. A producer of value is expected to set one of these
-// variants. Absence of any variant indicates an error.
-//
-// The JSON representation for `Value` is JSON value.
+// variants. Absence of any variant is an invalid state.
 message Value {
   // The kind of value.
   oneof kind {
-    // Represents a null value.
+    // Represents a JSON `null`.
     NullValue null_value = 1;
-    // Represents a double value.
+
+    // Represents a JSON number. Must not be `NaN`, `Infinity` or
+    // `-Infinity`, since those are not supported in JSON. This also cannot
+    // represent large Int64 values, since JSON format generally does not
+    // support them in its number type.
     double number_value = 2;
-    // Represents a string value.
+
+    // Represents a JSON string.
     string string_value = 3;
-    // Represents a boolean value.
+
+    // Represents a JSON boolean (`true` or `false` literal in JSON).
     bool bool_value = 4;
-    // Represents a structured value.
+
+    // Represents a JSON object.
     Struct struct_value = 5;
-    // Represents a repeated `Value`.
+
+    // Represents a JSON array.
     ListValue list_value = 6;
   }
 }
 
-// `NullValue` is a singleton enumeration to represent the null value for the
-// `Value` type union.
+// Represents a JSON `null`.
 //
-// The JSON representation for `NullValue` is JSON `null`.
+// `NullValue` is a sentinel, using an enum with only one value to represent
+// the null value for the `Value` type union.
+//
+// A field of type `NullValue` with any value other than `0` is considered
+// invalid. Most ProtoJSON serializers will emit a Value with a `null_value` set
+// as a JSON `null` regardless of the integer value, and so will round trip to
+// a `0` value.
 enum NullValue {
   // Null value.
   NULL_VALUE = 0;
 }
 
-// `ListValue` is a wrapper around a repeated field of values.
-//
-// The JSON representation for `ListValue` is JSON array.
+// Represents a JSON array.
 message ListValue {
   // Repeated field of dynamically typed values.
   repeated Value values = 1;


### PR DESCRIPTION
Fixes two pre-existing CI failures that block the release pipeline. They surfaced when the first real schema (`proto/infoblox/authz/v1`) merged — the **APX On Merge** run failed, so no release/catalog was produced.

## 1. `apx.yaml` — drop unrecognized `tools.jsonschemadiff`

The current apx build rejects `tools.jsonschemadiff` (line 49) as an unknown field, so the **entire `apx.yaml` fails to load** → `org` can't be read → `apx catalog generate` aborts with *"org is required"*.

- before: `Could not load config for policy check: line 49: unknown field 'tools.jsonschemadiff'`
- after: `apx release prepare proto/infoblox/authz/v1 … --dry-run` → *Policy check passed (2 rules); go.mod will be generated at proto/infoblox/authz during submit.*

> **Version-skew note for reviewers:** if jsonschemadiff version-pinning is still wanted, the alternative fix is bumping the apx version in the `apis-catalog` CI image so it recognizes the key. This PR takes the minimal "make the config parse" path.

## 2. Sync third-party protos

`scripts/sync-third-party.sh --check-only` was failing (the vendored `google/protobuf/*` well-known-types drifted from buf.build). Ran `scripts/sync-third-party.sh` and committed the result; `--check-only` is now clean.

Together these turn the release pipeline green so the merged `infoblox.authz.v1` schema can be released.
