### PR TITLE
Add release-finalize workflow; repo-scoped catalog image

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -104,7 +104,8 @@ jobs:
     needs: [snapshot-tags]
     if: always()  # Run even if snapshot-tags was skipped (no release manifests)
     env:
-      IMAGE: ghcr.io/infobloxopen/${{ github.event.repository.name }}-catalog
+      # Repo-scoped package — the location apx v0.12.0 catalog discovery expects.
+      IMAGE: ghcr.io/infobloxopen/${{ github.event.repository.name }}/catalog
     steps:
       - name: Generate App Token
         id: app-token
@@ -112,6 +113,7 @@ jobs:
         with:
           app-id: ${{ secrets.APX_APP_ID }}
           private-key: ${{ secrets.APX_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@v4
         with:
@@ -122,7 +124,7 @@ jobs:
         uses: infobloxopen/apx@main
 
       - name: Validate schemas
-        run: apx lint || true  # Don't fail on lint if no protos on main
+        run: apx lint
 
       - name: Generate catalog data
         run: apx catalog generate --output catalog/catalog.yaml

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,0 +1,63 @@
+name: APX Release Finalize
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  finalize:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'apx/release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APX_APP_ID }}
+          private-key: ${{ secrets.APX_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install APX
+        uses: infobloxopen/apx@main
+
+      - name: Parse release coordinates
+        id: rel
+        env:
+          # Release PR titles are "release: <api-id>@<version>" (set by
+          # apx release submit). Parsed via env to avoid script injection.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          REST="${PR_TITLE#release: }"
+          echo "api=${REST%@*}" >> "$GITHUB_OUTPUT"
+          echo "version=${REST##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        run: |
+          git config user.name "apx-release[bot]"
+          git config user.email "apx-release[bot]@users.noreply.github.com"
+
+      - name: Finalize release (tag + record)
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          apx release finalize \
+            --api "${{ steps.rel.outputs.api }}" \
+            --version "${{ steps.rel.outputs.version }}" \
+            --commit "${{ github.event.pull_request.merge_commit_sha }}" \
+            --skip-catalog
+
+      - name: Upload release record
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-record-${{ steps.rel.outputs.version }}
+          path: .apx-release-record.yaml


### PR DESCRIPTION
Brings the public canonical repo up to the apx v0.12.0 release pipeline (mirror of Infoblox-CTO/apis#118).

- **`release-finalize.yml` (new):** merged release PRs (`apx/release/*`) run `apx release finalize --api … --version …` on the merge commit — re-validates, cuts the canonical tag, uploads the release record. Nothing previously invoked finalize, which is why this repo has zero release tags.
- **`on-merge.yml`:** catalog image becomes repo-scoped `ghcr.io/infobloxopen/apis/catalog` (the location apx v0.12.0 discovery expects); app token gains `owner:`; `apx lint` is strict now that main carries first-party protos. **Deliberately preserved over the template:** the `snapshot-tags` job (the `releases/**` third-party manifest flow paired with `release-ci.yml`) and the `GITHUB_TOKEN` GHCR login (native `packages:write`).

Unblocks cutting `proto/infoblox/authz/v1 @ v1.0.0-alpha.1` here, which devedge-sdk (public) will consume.