### PR TITLE
release: proto/infoblox/authz/v1@v1.0.0-alpha.1

### DIFF
--- a/proto/infoblox/authz/go.mod
+++ b/proto/infoblox/authz/go.mod
@@ -1,0 +1,3 @@
+module github.com/infobloxopen/apis/proto/infoblox/authz
+
+go 1.21


### PR DESCRIPTION
Automated release submission of API `proto/infoblox/authz/v1` at version `v1.0.0-alpha.1`.

- **Tag**: `proto/infoblox/authz/v1.0.0-alpha.1`
- **Source**: `github.com/infobloxopen/apis/proto/infoblox/authz/v1`

Created by `apx release submit`.